### PR TITLE
Cleanup after <iframe> implementation of MathCell

### DIFF
--- a/symja_web/src/main/webapp/index.html
+++ b/symja_web/src/main/webapp/index.html
@@ -63,8 +63,6 @@
 <script type="text/javascript" src="/media/js/scriptaculous/sound.js"></script>
 <!--<script type="text/javascript" src="/media/js/scriptaculous/scriptaculous.js"></script>-->
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/paulmasson/mathcell@1.7.0/build/mathcell.js"></script>
-
 </head>
 
 <body>

--- a/symja_web/src/main/webapp/media/js/symja.js
+++ b/symja_web/src/main/webapp/media/js/symja.js
@@ -300,7 +300,6 @@ function createLine(value) {
 	} else if (value.startsWith('<iframe')) {
 		var dom = document.createElement('div'); 
 		dom.setAttribute('id', 'mathcell');
-		dom.setAttribute('class', 'mathcell');
 		dom.setAttribute('style', 'width: 600px; height: 440px; margin: 0; padding: 0');
 		dom.update(value); 
 		return dom;


### PR DESCRIPTION
Since the script is being loaded inside the <iframe> it is no longer needed on the main app page.

The <div> containing the MathCell doesn't need that class: that's creating display issues.